### PR TITLE
Add simple job-server style authentication

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -1,15 +1,28 @@
 import aiofiles
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Security
 from fastapi.responses import FileResponse
+from fastapi.security.api_key import APIKeyHeader
 
 from hatch import config
 from hatch.models import FilesIndex
 
 
-app = FastAPI()
+api_key_header = APIKeyHeader(name="Authorization")
 
 
-@app.get("/workspace/{workspace}", response_model=FilesIndex)
+def validate(auth_token: str = Security(api_key_header)):
+    if auth_token != config.BACKEND_TOKEN:
+        raise HTTPException(403, "Unauthorised")
+
+
+app = FastAPI(dependencies=[Depends(validate)])
+
+
+@app.get(
+    "/workspace/{workspace}",
+    response_model=FilesIndex,
+    dependencies=[Depends(validate)],
+)
 def workspace_index(workspace: str):
     """Return an index of the files on disk in this workspace."""
     path = config.WORKSPACES / workspace
@@ -24,10 +37,9 @@ def workspace_index(workspace: str):
 async def workspace_file(workspace: str, name: str):
     """Return the contents of a file in this workspace.
 
-    Note: this one API is async, to serve files efficiently."""
+    Note: this API is async, to serve files efficiently."""
     path = config.WORKSPACES / workspace / name
     try:
-        # we need to async this stat for this api
         await aiofiles.os.stat(path)
     except FileNotFoundError:
         raise HTTPException(404, f"File {name} not found in workspace {workspace}")

--- a/hatch/config.py
+++ b/hatch/config.py
@@ -14,3 +14,6 @@ if CACHE is None:
 else:  # pragma: no cover
     CACHE = Path(CACHE)
     assert CACHE.exists()
+
+BACKEND_TOKEN = os.environ.get("BACKEND_TOKEN")
+assert BACKEND_TOKEN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
-import hatch.config
+
+# set a testing secret
+os.environ["BACKEND_TOKEN"] = "secret"
+import hatch.config  # noqa: E402
 
 
 @dataclass


### PR DESCRIPTION
This based on the same scheme as job-server, passing a secret in
Authoriztion header.

This will be expanded later to also support a signed token in the
Authorization header
