### PR TITLE
Add release file index and serving apis

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -36,8 +36,25 @@ def validate_workspace(workspace):
     path = config.WORKSPACES / workspace
     if not path.exists():
         raise HTTPException(404, f"Workspace {workspace} not found")
-
     return path
+
+
+def validate_release(workspace_dir, release_id):
+    """Validate a Release exists on disk."""
+    path = workspace_dir / "releases" / release_id
+    if not path.exists():
+        raise HTTPException(404, f"Release {release_id} not found")
+    return path
+
+
+async def aioexists(path):
+    """async version for use in async file serving APIs."""
+    try:
+        await aiofiles.os.stat(str(path))
+    except FileNotFoundError:
+        return False
+    else:
+        return True
 
 
 @app.get("/workspace/{workspace}/current/", response_model=schema.IndexSchema)
@@ -57,9 +74,7 @@ async def workspace_file(
 
     Note: this API is async, to serve files efficiently."""
     path = config.WORKSPACES / workspace / name
-    try:
-        await aiofiles.os.stat(path)
-    except FileNotFoundError:
+    if not await aioexists(path):
         raise HTTPException(404, f"File {name} not found in workspace {workspace}")
 
     # FastAPI supports async file responses
@@ -85,3 +100,30 @@ def workspace_release(
     response = models.create_release(workspace, workspace_dir, release, token.user)
     # forward job-servers response back to client
     return response
+
+
+@app.get("/workspace/{workspace}/release/{release_id}")
+def release_index(
+    workspace: str,
+    release_id: str,
+    request: Request,
+    token: AuthToken = Depends(validate),
+):
+    """Index of files in a Release."""
+    workspace_dir = validate_workspace(workspace)
+    release_dir = validate_release(workspace_dir, release_id)
+    return models.get_index(release_dir, request.url.path + "/")
+
+
+@app.get("/workspace/{workspace}/release/{release_id}/{name:path}")
+async def release_file(
+    workspace: str, release_id: str, name: str, token: AuthToken = Depends(validate)
+):
+    """Return the contents of a file in this workspace.
+
+    Note: this API is async, to serve files efficiently."""
+    path = config.WORKSPACES / workspace / "releases" / release_id / name
+    if not await aioexists(path):
+        raise HTTPException(404, f"File {name} not found in release {release_id}")
+
+    return FileResponse(path)

--- a/hatch/config.py
+++ b/hatch/config.py
@@ -15,16 +15,6 @@ else:  # pragma: no cover
     CACHE = Path(CACHE)
     assert CACHE.exists()
 
-# directory to copy pending release file to
-RELEASES = os.environ.get("RELEASES", None)
-if RELEASES is None:
-    RELEASES = WORKSPACES / "releases"
-    RELEASES.mkdir(exist_ok=True)
-else:  # pragma: no cover
-    RELEASES = Path(RELEASES)
-    assert RELEASES.exists()
-
-
 BACKEND_TOKEN = os.environ.get("BACKEND_TOKEN")
 assert BACKEND_TOKEN
 BACKEND = os.environ.get("BACKEND", "test-backend")

--- a/hatch/models.py
+++ b/hatch/models.py
@@ -96,8 +96,11 @@ def create_release(workspace, workspace_dir, release, user):
         # tell job-server about the files
         response = api_client.create_release(workspace, release, user)
 
+        # copy file into releases subdir of workspace dir
+        workspace_release_dir = workspace_dir / "releases"
+        workspace_release_dir.mkdir(parents=True, exist_ok=True)
         # rename tempdir to match release id
-        os.rename(tmp, config.RELEASES / response.headers["Release-Id"])
+        os.rename(tmp, workspace_release_dir / response.headers["Release-Id"])
     except Exception:
         tmpdir.cleanup()
         raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import os
 import secrets
-from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 
@@ -9,34 +7,28 @@ import pytest
 # force testing config
 os.environ["BACKEND_TOKEN"] = secrets.token_hex(32)
 os.environ["SERVER_HOST"] = "http://testserver"
+
+# now we can import hatch stuff
 from hatch import config, signing  # noqa: E402
+from tests import factories  # noqa: E402
 
 
 signing.set_default_key(config.BACKEND_TOKEN, config.BACKEND)
 
 
-@dataclass
-class Workspace:
-    path: Path
-    cache: Path
-    root: Path
-
-    def write(self, name, contents):
-        path = self.path / name
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(contents)
-        return path
+@pytest.fixture(autouse=True)
+def set_up_storage(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    monkeypatch.setattr(config, "WORKSPACES", tmp_path)
+    monkeypatch.setattr(config, "CACHE", cache)
 
 
 @pytest.fixture
-def workspace(tmp_path, monkeypatch):
-    workspace = tmp_path / "workspace"
-    cache = tmp_path / "cache"
-    releases = tmp_path / "releases"
-    workspace.mkdir()
-    cache.mkdir()
-    releases.mkdir()
-    monkeypatch.setattr(config, "WORKSPACES", tmp_path)
-    monkeypatch.setattr(config, "CACHE", cache)
-    monkeypatch.setattr(config, "RELEASES", releases)
-    return Workspace(workspace, cache, tmp_path)
+def workspace():
+    return factories.WorkspaceFactory("workspace")
+
+
+@pytest.fixture
+def release(workspace):
+    return factories.ReleaseFactory(name="release_id", workspace=workspace)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+
+from hatch import config
+from hatch.models import get_sha
+
+
+class BaseFactory:
+    root_dir = None
+
+    def __init__(self, name):
+        self.name = name
+        self.path = self.root_dir / name
+        self.path.mkdir(parents=True)
+
+    def write(self, name, contents):
+        path = self.path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents)
+        return path
+
+    def get_date(self, name, iso=True):
+        path = self.path / name
+        stat = path.stat()
+        dt = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
+        if iso:
+            return dt.isoformat()
+        else:
+            return dt
+
+    def get_sha(self, name):
+        return get_sha(self.path / name)
+
+
+class WorkspaceFactory(BaseFactory):
+    # use property for dynamic look up
+    @property
+    def root_dir(self):
+        return config.WORKSPACES
+
+
+class ReleaseFactory(BaseFactory):
+    def __init__(self, name, workspace):
+        self.workspace = workspace
+        super().__init__(name)
+
+    # use property for dynamic look up
+    @property
+    def root_dir(self):
+        return self.workspace.path / "releases"
+
+    @property
+    def id(self):  # noqa: A003
+        return self.name

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,3 @@
-import hashlib
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin
 
@@ -6,6 +5,7 @@ import itsdangerous
 from fastapi.testclient import TestClient
 
 from hatch import app, config, schema, signing
+from tests.factories import WorkspaceFactory
 
 
 client = TestClient(app.app)
@@ -69,27 +69,22 @@ def test_index_api(workspace):
     response = client.get(url, headers=auth_headers())
     assert response.status_code == 200
 
-    def get_date(name):
-        path = workspace.path / name
-        stat = path.stat()
-        return datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat()
-
     assert response.json() == {
         "files": [
             {
                 "name": "output/file1.txt",
                 "url": "/workspace/workspace/current/output/file1.txt",
                 "size": 5,
-                "sha256": hashlib.sha256(b"test1").hexdigest(),
-                "date": get_date("output/file1.txt"),
+                "sha256": workspace.get_sha("output/file1.txt"),
+                "date": workspace.get_date("output/file1.txt"),
                 "user": None,
             },
             {
                 "name": "output/file2.txt",
                 "url": "/workspace/workspace/current/output/file2.txt",
                 "size": 5,
-                "sha256": hashlib.sha256(b"test2").hexdigest(),
-                "date": get_date("output/file2.txt"),
+                "sha256": workspace.get_sha("output/file2.txt"),
+                "date": workspace.get_date("output/file2.txt"),
                 "user": None,
             },
         ]
@@ -164,7 +159,7 @@ def test_workspace_release_success(workspace, httpx_mock):
     workspace.write("output/file.txt", "test")
 
     release = schema.Release(
-        files={"output/file.txt": hashlib.sha256(b"test").hexdigest()}
+        files={"output/file.txt": workspace.get_sha("output/file.txt")}
     )
 
     url = "/workspace/workspace/release"
@@ -175,3 +170,88 @@ def test_workspace_release_success(workspace, httpx_mock):
     )
 
     assert response.status_code == 201
+
+
+def test_release_index_api_bad_workspace():
+    url = "/workspace/bad/release/id"
+    response = client.get(url, headers=auth_headers("bad"))
+    assert response.status_code == 404
+
+
+def test_release_index_api_bad_release():
+    url = "/workspace/workspace/release/id"
+    response = client.get(url, headers=auth_headers())
+    assert response.status_code == 404
+
+
+def test_release_cannot_access_different_workspaces_release(release):
+    # check we can access the release normally
+    response = client.get(
+        f"/workspace/workspace/release/{release.id}", headers=auth_headers()
+    )
+    assert response.status_code == 200
+
+    WorkspaceFactory("other")
+    # allow access to other workspace
+    headers = auth_headers("other")
+    # use above create to try access release from original workspace
+    url = f"/workspace/other/release/{release.id}"
+    response = client.get(url, headers=headers)
+    assert response.status_code == 404
+
+
+def test_release_index_api(release):
+    release.write("output/file1.txt", "test1")
+    release.write("output/file2.txt", "test2")
+
+    url = f"/workspace/workspace/release/{release.id}"
+    response = client.get(url, headers=auth_headers())
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "files": [
+            {
+                "name": "output/file1.txt",
+                "url": f"/workspace/workspace/release/{release.id}/output/file1.txt",
+                "size": 5,
+                "sha256": release.get_sha("output/file1.txt"),
+                "date": release.get_date("output/file1.txt"),
+                "user": None,
+            },
+            {
+                "name": "output/file2.txt",
+                "url": f"/workspace/workspace/release/{release.id}/output/file2.txt",
+                "size": 5,
+                "sha256": release.get_sha("output/file2.txt"),
+                "date": release.get_date("output/file2.txt"),
+                "user": None,
+            },
+        ]
+    }
+
+
+def test_release_file_api_invalid_token_url():
+    url = "/workspace/workspace/release/id/bad.txt"
+    response = client.get(url, headers=auth_headers("other"))
+    assert response.status_code == 403
+
+
+def test_release_file_api_workspace_notfound(release):
+    release.write("output/file.txt", "test")
+    url = f"/workspace/bad/release/{release.id}/output/file.txt"
+    response = client.get(url, headers=auth_headers("bad"))
+    assert response.status_code == 404
+
+
+def test_release_file_api_not_found(release):
+    url = f"/workspace/workspace/release/{release.id}/bad.txt"
+    response = client.get(url, headers=auth_headers())
+    assert response.status_code == 404
+
+
+def test_release_file_api(release):
+    release.write("output/file.txt", "test")
+    url = f"/workspace/workspace/release/{release.id}/output/file.txt"
+    response = client.get(url, headers=auth_headers())
+    assert response.status_code == 200
+    assert response.content == b"test"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,7 +14,7 @@ def test_get_sha_caches_sha(workspace):
 
     expected_sha = hashlib.sha256(b"test").hexdigest()
     assert sha == expected_sha
-    assert (workspace.cache / "workspace/file.txt").read_text() == expected_sha
+    assert (config.CACHE / "workspace/file.txt").read_text() == expected_sha
 
 
 def test_get_sha_uses_cached_sha(workspace):
@@ -22,7 +22,7 @@ def test_get_sha_uses_cached_sha(workspace):
 
     time.sleep(0.01)
 
-    c = workspace.cache / "workspace/file.txt"
+    c = config.CACHE / "workspace/file.txt"
     c.parent.mkdir()
     c.write_text("cached")
 
@@ -32,7 +32,7 @@ def test_get_sha_uses_cached_sha(workspace):
 
 
 def test_get_sha_stale_cache(workspace):
-    c = workspace.cache / "workspace/file.txt"
+    c = config.CACHE / "workspace/file.txt"
     c.parent.mkdir()
     c.write_text("cached")
 
@@ -45,23 +45,35 @@ def test_get_sha_stale_cache(workspace):
     # it should use actual hash an update file
     expected_sha = hashlib.sha256(b"test").hexdigest()
     assert sha == expected_sha
-    assert (workspace.cache / "workspace/file.txt").read_text() == expected_sha
+    assert (config.CACHE / "workspace/file.txt").read_text() == expected_sha
 
 
 def test_get_index(workspace):
     workspace.write("output/file1.txt", "test1")
     workspace.write("output/file2.txt", "test2")
 
-    index = models.get_index(workspace.path, "/url/")
+    index = models.get_index(workspace.path, "/url/").dict()
 
-    assert index.files[0].name == "output/file1.txt"
-    assert index.files[0].url == "/url/output/file1.txt"
-    assert index.files[0].size == 5
-    assert index.files[0].sha256 == hashlib.sha256(b"test1").hexdigest()
-    assert index.files[1].name == "output/file2.txt"
-    assert index.files[1].url == "/url/output/file2.txt"
-    assert index.files[1].size == 5
-    assert index.files[1].sha256 == hashlib.sha256(b"test2").hexdigest()
+    assert index == {
+        "files": [
+            {
+                "name": "output/file1.txt",
+                "url": "/url/output/file1.txt",
+                "size": 5,
+                "sha256": workspace.get_sha("output/file1.txt"),
+                "date": workspace.get_date("output/file1.txt", iso=False),
+                "user": None,
+            },
+            {
+                "name": "output/file2.txt",
+                "url": "/url/output/file2.txt",
+                "size": 5,
+                "sha256": workspace.get_sha("output/file2.txt"),
+                "date": workspace.get_date("output/file2.txt", iso=False),
+                "user": None,
+            },
+        ]
+    }
 
 
 def test_validate_release_errors(workspace):
@@ -69,7 +81,7 @@ def test_validate_release_errors(workspace):
 
     release = schema.Release(
         files={
-            "badfile": hashlib.sha256(b"test").hexdigest(),
+            "badfile": workspace.get_sha("output/file.txt"),
             "output/file.txt": "badsha",
         }
     )
@@ -83,9 +95,7 @@ def test_validate_release_valid(workspace):
     workspace.write("output/file.txt", "test")
 
     release = schema.Release(
-        files={
-            "output/file.txt": hashlib.sha256(b"test").hexdigest(),
-        }
+        files={"output/file.txt": workspace.get_sha("output/file.txt")}
     )
     assert models.validate_release("workspace", workspace.path, release) == []
 
@@ -101,7 +111,7 @@ def test_create_release(workspace, httpx_mock):
     workspace.write("output/file.txt", "test")
 
     release = schema.Release(
-        files={"output/file.txt": hashlib.sha256(b"test").hexdigest()}
+        files={"output/file.txt": workspace.get_sha("output/file.txt")}
     )
 
     response = models.create_release("workspace", workspace.path, release, "user")
@@ -109,7 +119,7 @@ def test_create_release(workspace, httpx_mock):
     release_id = response.headers["Release-Id"]
     assert release_id == "id"
 
-    release_dir = config.RELEASES / release_id
+    release_dir = workspace.path / "releases" / release_id
     assert release_dir.exists()
 
     for f in models.get_files(release_dir):


### PR DESCRIPTION
I release there was a security issue where a valid token for one
workspace could be used to access any release from any workspace. To
fix, I moved the releases to be stored inside their workspace dir, and
use that as an access control.

In the process, I refactored the test machinery out into reusable
factories.
