### PR TITLE
Add final API, file upload.

### DIFF
--- a/hatch/models.py
+++ b/hatch/models.py
@@ -115,3 +115,9 @@ def copy_files(srcdir, files, dstdir):
         dst = dstdir / f
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(src, dst)
+
+
+def upload_file(release_id, name, path, user):
+    """Upload a file to job-server."""
+    # this is really simple, there's nothing to except make the request
+    return api_client.upload_file(release_id, name, path, user)


### PR DESCRIPTION
This is the only API that is not a mirror of job-server's API, as it
does not post the file, just it's name, and the service uploads the
file.
