### PR TITLE
Remove scopes from auth token.

### DIFF
--- a/dev-token.py
+++ b/dev-token.py
@@ -12,9 +12,6 @@ def token(argv=sys.argv):
     parser.add_argument("workspace", help="workspace for token url")
     parser.add_argument("--user", "-u", default=getpass.getuser(), help="token user")
     parser.add_argument(
-        "--scope", "-s", default="view", help="token scope [view, release, upload]"
-    )
-    parser.add_argument(
         "--duration", "-d", default=60, help="how many minutes is the token valid for"
     )
 
@@ -22,7 +19,7 @@ def token(argv=sys.argv):
 
     url = urljoin(config.SERVER_HOST, f"/workspace/{args.workspace}")
     expiry = datetime.now(timezone.utc) + timedelta(minutes=args.duration)
-    token = signing.AuthToken(url=url, user=args.user, expiry=expiry, scope=args.scope)
+    token = signing.AuthToken(url=url, user=args.user, expiry=expiry)
     print(token.sign())
 
 

--- a/hatch/app.py
+++ b/hatch/app.py
@@ -115,9 +115,6 @@ def workspace_release(
 ):
     """Create a Release locally and in job-server."""
 
-    if token.scope not in ["release", "upload"]:
-        raise HTTPException(403, "Forbidden")
-
     workspace_dir = validate_workspace(workspace)
     errors = models.validate_release(workspace, workspace_dir, release)
     if errors:
@@ -171,9 +168,6 @@ def release_file_upload(
     token: AuthToken = Depends(validate),
 ):
     """Upload a file from a release to job-server."""
-    if token.scope != "upload":
-        raise HTTPException(403, "Forbidden")
-
     name = release_file.name
     workspace_dir = validate_workspace(workspace)
     release_dir = validate_release(workspace_dir, release_id)

--- a/hatch/signing.py
+++ b/hatch/signing.py
@@ -1,6 +1,5 @@
 import hashlib
 from datetime import datetime, timezone
-from enum import Enum
 
 import itsdangerous
 from pydantic import BaseModel, Field, ValidationError, root_validator, validator
@@ -50,29 +49,37 @@ def set_default_key(key, salt):
     _signer = create_signer(key, salt)
 
 
-class TokenScopes(str, Enum):
-    view = "view"
-    release = "release"
-    upload = "upload"
-
-
 class AuthToken(BaseModel):
     """A signed auth token.
 
-    The signed format json serialized version this model, with a signature.
+    The signed format is a json serialized version of this model, with
+    a signature.
 
     This model includes all the logic needed to generate, sign, parse and
     validate a signed auth token. This is so that we can ensure that it is very
     difficult to create an invalid token by accident, and so in future we can
     share one implementation of this token between projects.
+
+    Note: we sign the full url, rather than including business concepts like
+    'workspace' or 'release', and signing those. The assumption here is that
+    the url path will include a business scope, e.g.
+    `https://example.com/workspaces/MYWORKSPACE`, and that all urls under this
+    prefix are valid for this token.
+
+    This gives us a few benefits:
+
+    1) more generic token format that can be used on different parts of the system.
+    2) including the full domain prevents cross backend token usage
+    3) validating the url makes it easier for web frameworks to automatically
+       apply the validation, as they don't need to understand the business logic.
+
     """
 
-    url: str = Field(description="url prefix the token is valid for")
-    user: str = Field(decription="the user this token was signed for")
-    expiry: datetime = Field(
-        description="the UTC datetime after which this token expires"
+    url: str = Field(
+        description="Full url prefix the token is valid for, e.g. http://domain.com/path/arg"
     )
-    scope: TokenScopes = Field(TokenScopes.view, description="the scope of this token")
+    user: str = Field(decription="The user this token was signed for")
+    expiry: datetime = Field(description="UTC datetime after which this token expires")
 
     class Config:
         # do not allow anyone to set values after instantiation
@@ -101,7 +108,7 @@ class AuthToken(BaseModel):
         # values dict contains all fields that have been validated.
         if "expiry" in values:
             return values
-        if all(k in values for k in ["url", "user", "scope"]):
+        if all(k in values for k in ["url", "user"]):
             raise cls.Expired()
         return values
 

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -23,7 +23,6 @@ def test_token_sign_verify_roundtrip():
         url="https://example.com/url",
         user="user",
         expiry=datetime.now(timezone.utc) + timedelta(minutes=1),
-        scope="view",
     )
     token_string = token1.sign()
 
@@ -37,17 +36,6 @@ def test_token_object_url_invalid():
             url="bad",
             user="user",
             expiry=datetime.now(timezone.utc) + timedelta(minutes=1),
-            scope="view",
-        )
-
-
-def test_token_object_scope_invalid():
-    with pytest.raises(ValidationError):
-        signing.AuthToken(
-            url="https://example.com/url",
-            user="user",
-            expiry=datetime.now(timezone.utc) + timedelta(minutes=1),
-            scope="bad scope",
         )
 
 
@@ -57,7 +45,6 @@ def test_token_object_expired():
             url="https://example.com/url",
             user="user",
             expiry=datetime.now(timezone.utc) - timedelta(minutes=1),
-            scope="view",
         )
 
 
@@ -66,7 +53,6 @@ def test_token_verify_mismatched_secrets():
         url="https://example.com/url",
         user="user",
         expiry=datetime.now(timezone.utc) + timedelta(minutes=1),
-        scope="view",
     )
     signer = itsdangerous.Signer("bad secret")
     token = create_raw_token(payload, signer)
@@ -87,7 +73,6 @@ def test_token_verify_expired():
         url="https://example.com/url",
         user="user",
         expiry=datetime.now(timezone.utc) - timedelta(minutes=1),
-        scope="view",
     )
     token = create_raw_token(payload)
     with pytest.raises(signing.AuthToken.Expired):
@@ -99,7 +84,6 @@ def test_token_verify_wrong_all_the_things():
         url="bad url",
         # missing user
         expiry=datetime.now(timezone.utc) - timedelta(minutes=1),
-        scope="bad scope",
     )
     token = create_raw_token(payload)
     with pytest.raises(ValidationError) as exc_info:
@@ -109,4 +93,3 @@ def test_token_verify_wrong_all_the_things():
     assert "url" in errors
     assert "user" in errors
     assert "expiry" in errors
-    assert "scope" in errors


### PR DESCRIPTION
We do not need them, we just need the signed user. Job-server will
validate that the user has the correct permissions.
