### PR TITLE
Remove the default signer, and make the key and salt explict

### DIFF
--- a/dev-token.py
+++ b/dev-token.py
@@ -20,7 +20,7 @@ def token(argv=sys.argv):
     url = urljoin(config.SERVER_HOST, f"/workspace/{args.workspace}")
     expiry = datetime.now(timezone.utc) + timedelta(minutes=args.duration)
     token = signing.AuthToken(url=url, user=args.user, expiry=expiry)
-    print(token.sign())
+    print(token.sign(config.BACKEND_TOKEN, salt="hatch"))
 
 
 if __name__ == "__main__":

--- a/hatch/__init__.py
+++ b/hatch/__init__.py
@@ -1,4 +1,0 @@
-from hatch import config, signing
-
-
-signing.set_default_key(config.BACKEND_TOKEN, salt="hatch")

--- a/hatch/app.py
+++ b/hatch/app.py
@@ -39,7 +39,7 @@ def reverse_url(view_name, **kwargs):
 
 def validate(request: Request, auth_token: str = Security(api_key_header)):
     try:
-        token = AuthToken.verify(auth_token)
+        token = AuthToken.verify(auth_token, config.BACKEND_TOKEN, "hatch")
     except AuthToken.Expired:
         raise HTTPException(401, "Unauthorized")
     except ValidationError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,8 @@ os.environ["SERVER_HOST"] = "http://testserver"
 os.environ["API_SERVER"] = "https://jobs.opensafely.org"
 
 # now we can import hatch stuff
-from hatch import config, signing  # noqa: E402
+from hatch import config  # noqa: E402
 from tests import factories  # noqa: E402
-
-
-signing.set_default_key(config.BACKEND_TOKEN, salt="hatch")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This works better in a job-server setting, where there is no default
signer, it's per backend. Signer's are cheap to create, so we do it on
the fly.

Also, explicit is better than implicit
