### PR TITLE
Omit Direnv from Coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ exclude = '''
 [tool.coverage.run]
 branch = true
 omit = [
-   ".venv/*",
-   "dev-token.py",
+  ".direnv/*",
+  ".venv/*",
+  "dev-token.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
This mirrors the exclusion of direnv directories elsewhere in the config, and avoids direnv's python venv from being checked for coverage.