### PR TITLE
Fix some issues from testing on real workspaces on windows

### DIFF
--- a/hatch/schema.py
+++ b/hatch/schema.py
@@ -11,11 +11,24 @@ from typing import Dict, List
 from pydantic import BaseModel
 
 
+class UrlFileName(str):
+    """str file name that normalises path separators."""
+
+    @classmethod
+    def __get_validators__(cls):
+        """Tell pydantic how to validate me."""
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value):
+        return str(value).replace("\\", "/")
+
+
 class FileSchema(BaseModel):
     """Metadata for a workspace file."""
 
-    name: str
-    url: str
+    name: UrlFileName
+    url: UrlFileName
     size: int
     sha256: str
     user: str = None
@@ -37,7 +50,7 @@ class Release(BaseModel):
     Files is a dict with {name: sha256} mapping.
     """
 
-    files: Dict[str, str]
+    files: Dict[UrlFileName, str]
 
 
 class ReleaseFile(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import hashlib
 import time
+from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
@@ -46,6 +47,17 @@ def test_get_sha_stale_cache(workspace):
     expected_sha = hashlib.sha256(b"test").hexdigest()
     assert sha == expected_sha
     assert (config.CACHE / "workspace/file.txt").read_text() == expected_sha
+
+
+def test_get_files(workspace):
+    workspace.write("output/file.txt", "test")
+    # all these should be ignored
+    workspace.write("metadata/manifest.json", "test")
+    workspace.write("releases/id/file.txt", "test")
+    workspace.write(".git/config", "test")
+    workspace.write("output/.hidden", "test")
+
+    assert models.get_files(workspace.path) == [Path("output/file.txt")]
 
 
 def test_get_index(workspace):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from hatch.schema import UrlFileName
+
+
+def test_filename():
+    UrlFileName("a/b/c") == "a/b/c"
+    UrlFileName(r"a\b\c") == "a/b/c"
+    UrlFileName(Path("a/b/c")) == "a/b/c"
+    UrlFileName(Path(r"a\b\c")) == "a/b/c"


### PR DESCRIPTION
Exclude lots more files from current files listing:
 - metadata/
 - releases/
 - .*

Also, ensure all paths are normalised to url path separators in release
requests and indexes, to avoid windows \ separators appearing in urls
(which works but is ugly)
