### PR TITLE
Use Absolute File URLs

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -114,7 +114,7 @@ async def workspace_file(
     )
 
 
-@app.post("/workspace/{workspace}/release")
+@app.post("/workspace/{workspace}/release/")
 def workspace_release(
     workspace: str,
     release: schema.Release,

--- a/hatch/models.py
+++ b/hatch/models.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.parse import urljoin
 
 from hatch import api_client, config
 from hatch.schema import FileSchema, IndexSchema
@@ -57,7 +56,7 @@ def get_files(path):
     return list(sorted(filter(lambda p: not exclude(p), relative_paths)))
 
 
-def get_index(path, urlbase):
+def get_index(path, url_builder):
     files = []
     for name in get_files(path):
         abspath = path / name
@@ -66,7 +65,7 @@ def get_index(path, urlbase):
         files.append(
             FileSchema(
                 name=name,
-                url=urljoin(urlbase, str(name)),
+                url=url_builder(filename=str(name)),
                 size=stat.st_size,
                 sha256=get_sha(abspath),
                 date=date,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -110,7 +110,7 @@ def test_index_api(workspace):
         "files": [
             {
                 "name": "output/file1.txt",
-                "url": "/workspace/workspace/current/output/file1.txt",
+                "url": "http://testserver/workspace/workspace/current/output/file1.txt",
                 "size": 5,
                 "sha256": workspace.get_sha("output/file1.txt"),
                 "date": workspace.get_date("output/file1.txt"),
@@ -118,7 +118,7 @@ def test_index_api(workspace):
             },
             {
                 "name": "output/file2.txt",
-                "url": "/workspace/workspace/current/output/file2.txt",
+                "url": "http://testserver/workspace/workspace/current/output/file2.txt",
                 "size": 5,
                 "sha256": workspace.get_sha("output/file2.txt"),
                 "date": workspace.get_date("output/file2.txt"),
@@ -243,7 +243,7 @@ def test_release_index_api(release):
         "files": [
             {
                 "name": "output/file1.txt",
-                "url": f"/workspace/workspace/release/{release.id}/output/file1.txt",
+                "url": f"http://testserver/workspace/workspace/release/{release.id}/output/file1.txt",
                 "size": 5,
                 "sha256": release.get_sha("output/file1.txt"),
                 "date": release.get_date("output/file1.txt"),
@@ -251,7 +251,7 @@ def test_release_index_api(release):
             },
             {
                 "name": "output/file2.txt",
-                "url": f"/workspace/workspace/release/{release.id}/output/file2.txt",
+                "url": f"http://testserver/workspace/workspace/release/{release.id}/output/file2.txt",
                 "size": 5,
                 "sha256": release.get_sha("output/file2.txt"),
                 "date": release.get_date("output/file2.txt"),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -148,13 +148,13 @@ def test_file_api(workspace):
 
 
 def test_workspace_release_no_data():
-    url = "/workspace/workspace/release"
+    url = "/workspace/workspace/release/"
     response = client.post(url, headers=auth_headers())
     assert response.status_code == 422
 
 
 def test_workspace_release_workspace_not_exists():
-    url = "/workspace/notexists/release"
+    url = "/workspace/notexists/release/"
     response = client.post(
         url,
         json=schema.Release(files={}).dict(),
@@ -168,7 +168,7 @@ def test_workspace_release_workspace_bad_sha(workspace):
 
     release = schema.Release(files={"output/file1.txt": "badhash"})
 
-    url = "/workspace/workspace/release"
+    url = "/workspace/workspace/release/"
     response = client.post(
         url,
         data=release.json(),
@@ -193,7 +193,7 @@ def test_workspace_release_success(workspace, httpx_mock):
         files={"output/file.txt": workspace.get_sha("output/file.txt")}
     )
 
-    url = "/workspace/workspace/release"
+    url = "/workspace/workspace/release/"
     response = client.post(
         url,
         json=release.dict(),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,12 @@
 import hashlib
 import time
+from functools import partial
 from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
 
-from hatch import config, models, schema
+from hatch import app, config, models, schema
 
 
 def test_get_sha_caches_sha(workspace):
@@ -64,13 +65,15 @@ def test_get_index(workspace):
     workspace.write("output/file1.txt", "test1")
     workspace.write("output/file2.txt", "test2")
 
-    index = models.get_index(workspace.path, "/url/").dict()
+    url_builder = partial(app.reverse_url, "workspace_file", workspace=workspace.name)
+
+    index = models.get_index(workspace.path, url_builder).dict()
 
     assert index == {
         "files": [
             {
                 "name": "output/file1.txt",
-                "url": "/url/output/file1.txt",
+                "url": "http://testserver/workspace/workspace/current/output/file1.txt",
                 "size": 5,
                 "sha256": workspace.get_sha("output/file1.txt"),
                 "date": workspace.get_date("output/file1.txt", iso=False),
@@ -78,7 +81,7 @@ def test_get_index(workspace):
             },
             {
                 "name": "output/file2.txt",
-                "url": "/url/output/file2.txt",
+                "url": "http://testserver/workspace/workspace/current/output/file2.txt",
                 "size": 5,
                 "sha256": workspace.get_sha("output/file2.txt"),
                 "date": workspace.get_date("output/file2.txt", iso=False),


### PR DESCRIPTION
This uses the configured hostname for the service to generate absolute URLs for files when building an index response.

We configure the SPA with the URL for the index endpoint, with each file in that response containing its canonical API endpoint URL.  Currently this URL is relative to the host, which matches the response from job-server (an entirely sensible thing to have done!).

However, in a release-hatch driven API the SPA loads the index from the URL job-server has constructed, and then a user clicking on a file triggers a fetch to a relative URL, which uses the job-server hostname.  Since the index URL and file URL have an overlapping prefix (eg `/workspace/<name>/current`) it's tricky to let the SPA merge them without giving it some knowledge of how the URLs work, something we've actively avoided with this design.

Instead we can provide absolute URLs for the file endpoints and save the SPA having to know about them.