### PR TITLE
Add Dockerfile for deploying to non-TPP backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 ---
 name: CI
 
+env:
+    IMAGE_NAME: release-hatch
+
 on:
   push:
 
@@ -28,9 +31,33 @@ jobs:
           python-version: "3.9"
       - uses: extractions/setup-just@v1
       - name: Run tests
-#       env:  # Add environment variables required for tests
         run: |
           just test
+
+  docker:
+    needs: [test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+      - uses: extractions/setup-just@v1
+      - name: Build docker image and run tests in it
+        run: |
+          # build docker and run test
+          just docker-test
+          # test that prod image builds
+          just docker-build prod
+      - name: publish docker image
+        if: github.ref == 'refs/heads/main'
+        run: |
+            # use new GITHUB_TOKEN auth
+            IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+            docker tag $IMAGE_NAME $IMAGE_ID:latest
+            docker push $IMAGE_ID:latest
+
 
   lint-dockerfile:
     runs-on: ubuntu-latest

--- a/.test.env
+++ b/.test.env
@@ -1,0 +1,10 @@
+BACKEND_TOKEN="really really really really really really really long  secret"
+
+# local dev server
+SERVER_HOST=http://127.0.0.1:8001/
+
+# local job-server
+API_SERVER=http://127.0.0.1:8000/
+
+# workspaces dir
+WORKSPACES=./workspaces

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,159 @@
-# All Dockerfiles should start from this base image
-# Provide the TAG environment variable, or replace with the image version required
-FROM ghcr.io/opensafely-core/base-docker:$TAG
+# syntax=docker/dockerfile:1.2
+#################################################
+#
+# Create base image with python installed.
+#
+# DL3007 ignored because base-docker we specifically always want to build on
+# the latest base image, by design.
+#
+# hadolint ignore=DL3007
+FROM ghcr.io/opensafely-core/base-docker:latest as base-python
+
+# we are going to use an apt cache on the host, so disable the default debian
+# docker clean up that deletes that cache on every apt install
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
+# ensure fully working base python3 installation
+# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
+# use space efficient utility from base image
+RUN --mount=type=cache,target=/var/cache/apt \
+  /root/docker-apt-install.sh python3 python3-venv python3-pip python3-distutils tzdata ca-certificates
+
+# install any additional system dependencies
+# Uncomment if you add dependencies.txt
+#RUN --mount=type=bind,source=dependencies.txt,target=/dependencies.txt \
+#    --mount=type=cache,target=/var/cache/apt \
+#    /root/docker-apt-install.sh /dependencies.txt
+
+
+##################################################
+#
+# Build image
+#
+# Ok, now we have local base image with python and our system dependencies on.
+# We'll use this as the base for our builder image, where we'll build and
+# install any python packages needed.
+#
+# We use a separate, disposable build image to avoid carrying the build
+# dependencies into the production image.
+FROM base-python as builder
+
+# Install any system build dependencies
+# Uncomment if you add build-dependencies.txt
+#RUN --mount=type=bind,source=build-dependencies.txt,target=/build-dependencies.txt \
+#    --mount=type=cache,target=/var/cache/apt \
+#    /root/docker-apt-install.sh /build-dependencies.txt
+
+# Install everything in venv for isolation from system python libraries
+RUN python3 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
+
+# The cache mount means a) /root/.cache is not in the image, and b) it's preserved
+# between docker builds locally, for faster dev rebuild.
+COPY requirements.prod.txt /tmp/requirements.prod.txt
+
+# DL3042: using cache mount instead
+# DL3013: we always want latest pip/setuptools/wheel, at least for now
+# hadolint ignore=DL3042,DL3013
+RUN --mount=type=cache,target=/root/.cache \
+    python -m pip install -U pip setuptools wheel && \
+    python -m pip install --require-hashes --requirement /tmp/requirements.prod.txt
+
+
+##################################################
+#
+# Base project image
+#
+# Ok, we've built everything we need, build an image with all dependencies but
+# no code.
+#
+# Not including the code at this stage has two benefits:
+#
+# 1) this image only rebuilds when the handlful of files needed to build release-hatch-base
+#    changes. If we do `COPY . /app` now, this will rebuild when *any* file changes.
+#
+# 2) Ensures we *have* to mount the volume for dev image, as there's no embedded
+#    version of the code. Otherwise, we could end up accidentally using the
+#    version of the code included when the prod image was built.
+FROM base-python as release-hatch-base
+
+# Create a non-root user to run the app as
+RUN useradd --create-home appuser
+
+# copy venv over from builder image. These will have root:root ownership, but
+# are readable by all.
+COPY --from=builder /opt/venv /opt/venv
+
+# Ensure we're using the venv by default
+ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
+
+RUN mkdir /app
+WORKDIR /app
+VOLUME /app
+VOLUME /workspaces
+
+# This may not be nessecary, but it probably doesn't hurt
+ENV PYTHONPATH=/app
+
+# switch to running as the user
+USER appuser
+
+
+##################################################
+#
+# Production image
+#
+# Copy code in, add proper metadata
+FROM release-hatch-base as release-hatch-prod
+
+# Adjust this metadata to fit project. Note that the base-docker image does set
+# some basic metadata.
+LABEL org.opencontainers.image.title="release-hatch" \
+      org.opencontainers.image.description="project description" \
+      org.opencontainers.image.source="https://github.com/opensafely-core/project"
+
+# copy application code
+COPY . /app
+
+# We set command rather than entrypoint, to make it easier to run different
+# things from the cli
+CMD ["/app/entrypoints/prod.sh"]
+
+# finally, tag with build information. These will change regularly, therefore
+# we do them as the last action.
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.created=$BUILD_DATE
+ARG GITREF=unknown
+LABEL org.opencontainers.image.revision=$GITREF
+
+
+
+##################################################
+#
+# Dev image
+#
+# Now we build a dev image from our release-hatch-base image. This is basically
+# installing dev dependencies and changing the entrypoint
+#
+FROM release-hatch-base as release-hatch-dev
+
+# switch back to root to run the install of dev requirements.txt
+USER root
+
+# TODO: its possible python dev dependencies might need some additional build packages installed?
+
+# install development requirements
+COPY requirements.dev.txt /tmp/requirements.dev.txt
+# using cache mount instead
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache \
+    python -m pip install --require-hashes --requirement /tmp/requirements.dev.txt
+
+CMD ["/app/entrypoints/dev.sh"]
+
+# in dev, ensure appuser uid matches host user id
+ARG USERID=1000
+RUN usermod -u $USERID appuser
+
+# switch back to appuser
+USER appuser

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,60 @@
+# note: we do not run prod service with docker-compose, we use it just for
+# configuring the production build
+services:
+  prod:
+    image: release-hatch-prod
+    build:
+      context: .
+      # the prod stage in the Dockerfile
+      target: release-hatch-prod
+      # should speed up the build in CI, where we have a cold cache
+      cache_from:  # should speed up the build in CI, where we have a cold cache
+        - ghcr.io/opensafely/base-docker
+        - ghcr.io/opensafely/release-hatch
+      args:
+        # this makes the image work for later cache_from: usage
+        - BUILDKIT_INLINE_CACHE=1
+        # env vars supplied by just
+        - BUILD_DATE
+        - GITREF
+    # use dockers builitin PID daemon
+    init: true
+    # release-hatch's default port is 8001
+    ports:
+      - "8001:8001"
+    volumes:
+      - ./workspaces:/workspaces
+    # ensure WORKSPACES environent points volume
+    environment:
+      WORKSPACES: /workspaces
+
+  # main development service
+  dev:
+    extends:
+        service: prod
+    image: release-hatch-dev
+    container_name: release-hatch-dev
+    # running as a specific user id allows files written to mounted volumes by
+    # the docker container's default user to match the host uid, for convienience.
+    user: ${DOCKER_USERID:-1000}
+    build:
+      # the dev stage in the Dockerfile
+      target: release-hatch-dev
+      # pass the user id as build arg (default to 1000)
+      args:
+        - USERID=${DOCKER_USERID:-1000}
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+
+  # test runner service - uses dev-image with a different commnd
+  test:
+    extends:
+        service: dev
+    container_name: release-hatch-test
+    # override command
+    command: /opt/venv/bin/pytest
+    # different default test env
+    env_file:
+      - .test.env

--- a/entrypoints/dev.sh
+++ b/entrypoints/dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+port=$(echo "$SERVER_HOST" | awk -F: '{print $3}' | tr -d / )
+exec "$VIRTUAL_ENV/bin/uvicorn" hatch.app:app --reload --port "$port"

--- a/entrypoints/prod.sh
+++ b/entrypoints/prod.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+port=$(echo "$SERVER_HOST" | awk -F: '{print $3}' | tr -d / )
+exec "$VIRTUAL_ENV/bin/uvicorn" hatch.app:app --port "$port"

--- a/justfile
+++ b/justfile
@@ -96,7 +96,7 @@ docker-build env="dev": env
     export GITREF=$(git rev-parse --short HEAD)
 
     # build the thing
-    docker-compose build {{ env }}
+    docker-compose build --pull {{ env }}
 
 
 # run tests in docker container

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,5 +1,4 @@
--c requirements.prod.in
--r requirements.prod.in
+--constraint requirements.prod.txt
 
 # Additional dev requirements
 # To generate a requirements file that includes both prod and dev requirements, run:


### PR DESCRIPTION
Using this opportunity to try out a new Dockerfile methodology.

The docker is a multistage build, with the following stages:

```
┌──────────────────┐            ┌──────────────────┐
│   base-python    ├────────────►     builder      │
└────────┬─────────┘            └──────────┬───────┘
         │                                 │
         │                                 │COPY FROM
         │     ┌──────────────────┐        │
         └─────►release-hatch-base◄────────┘
               └────────┬─┬───────┘
                        │ │
                        │ │
┌──────────────────┐    │ │     ┌──────────────────┐
│release-hatch-prod◄────┘ └─────►release-hatch-dev │
└──────────────────┘            └──────────────────┘
```

 * base-python: basic python-on-ubuntu set up
 * builder: install/build requirements
 * release-hatch-base: base image with all deps but no code
 * release-hatch-prod: copy in code and tag with metadata
 * release-hatch-dev: installed dev dependencies and change entrypoint

To manage this complexity, we use docker-compose.yaml to build it, e.g.:

    docker-compose build [dev|prod] # build dev|prod image
    docker-compose up dev           # run dev server in docker
    docker-compose run --rm test    # run tests in docker

However, because we want to set some env vars and build args to build
properly, we wrap these in some justfile commands for consistency:

    just docker-build [dev|prod]
    just docker-run                 # will rebuild dev image
    just docker-test                # will rebuild dev image

The benefits of this approach are:

 * fast local re-builds
 * remote cache in CI to speed up CI builds
 * support local dev and test in docker
 * clean separation of prod/dev parts
 * smaller prod images.

If this approach bears out, my plan is to add it to repo-template as
a default.
