### PR TITLE
Don't use trailing slash for job-server location

### DIFF
--- a/dotenv-sample.env
+++ b/dotenv-sample.env
@@ -1,7 +1,7 @@
 BACKEND_TOKEN="really really really really really really really long secret"
 
 # local dev server
-SERVER_HOST=http://127.0.0.1:8001/
+SERVER_HOST=http://127.0.0.1:8001
 
 # local job-server
 API_SERVER=http://127.0.0.1:8000

--- a/dotenv-sample.env
+++ b/dotenv-sample.env
@@ -4,7 +4,7 @@ BACKEND_TOKEN="really really really really really really really long secret"
 SERVER_HOST=http://127.0.0.1:8001/
 
 # local job-server
-API_SERVER=http://127.0.0.1:8000/
+API_SERVER=http://127.0.0.1:8000
 
 # workspaces dir
 WORKSPACES=./workspaces


### PR DESCRIPTION
API_SERVER is used for the CORS middleware, but the calling server's
hostname arrives without a trailing slash, so mismatches.