### PR TITLE
Use the explit public url for validation

### DIFF
--- a/hatch/signing.py
+++ b/hatch/signing.py
@@ -9,7 +9,7 @@ import hashlib
 from datetime import datetime, timezone
 
 import itsdangerous
-from pydantic import BaseModel, Field, ValidationError, root_validator, validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 
 def create_signer(secret_key, salt):
@@ -76,8 +76,11 @@ class AuthToken(BaseModel):
         # do not allow anyone to set values after instantiation
         allow_mutation = False
 
+    # exceptions
     class Expired(Exception):
         pass
+
+    BadSignature = itsdangerous.BadSignature
 
     @validator("url")
     def check_url(cls, url):
@@ -115,10 +118,7 @@ class AuthToken(BaseModel):
     @classmethod
     def verify(cls, token_string, key, salt=None):
         signer = create_signer(key, salt)
-        try:
-            payload = signer.unsign(token_string)
-        except itsdangerous.BadSignature:
-            raise ValidationError(["bad signature"], cls)
+        payload = signer.unsign(token_string)
 
         # Use pydantics json parsing. The individual fields will be validated
         # as normal

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,7 +42,7 @@ def test_cors():
     assert "Authorization" in response.headers["access-control-allow-headers"]
 
 
-def test_validate_invalid_token():
+def test_validate_invalid_token_secret():
     url = "/workspace/workspace/current"
     token = create_raw_token(
         dict(
@@ -51,6 +51,25 @@ def test_validate_invalid_token():
             expiry=datetime.now(timezone.utc) + timedelta(hours=1),
         ),
         "bad secret" * 10,
+    )
+
+    # we can not easily call validate() directly, as fastapi's Request object
+    # is very much not sans-io, and thus difficult just instantiate.
+    response = client.get(url, headers={"Authorization": token})
+
+    assert response.status_code == 403
+
+
+def test_validate_invalid_token_values():
+    url = "/workspace/workspace/current"
+    token = create_raw_token(
+        dict(
+            url="bad url",
+            user="user",
+            expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+        ),
+        config.BACKEND_TOKEN,
+        salt="hatch",
     )
 
     # we can not easily call validate() directly, as fastapi's Request object

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -60,7 +60,7 @@ def test_token_verify_mismatched_secrets():
     )
     token = create_raw_token(payload, "secret1" * 10)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(signing.AuthToken.BadSignature):
         signing.AuthToken.verify(token, "secret2" * 10)
 
 


### PR DESCRIPTION
Previous we used the implicit hostname, now we explicitly use the
configure SERVER_HOST. This means we work when being accessed via nginx.

Also added some debug logging to validation errors, for future us.
