### PR TITLE
Refactor some docker based on prod set up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,9 @@ jobs:
       - name: publish docker image
         if: github.ref == 'refs/heads/main'
         run: |
-            IMAGE_ID=$REGISTRY/${{ github.repository_owner }}/$IMAGE_NAME
-            docker tag $IMAGE_NAME-prod $IMAGE_ID:latest
-            docker push $IMAGE_ID:latest
+            PUBLIC_IMAGE_NAME=$REGISTRY/${{ github.repository_owner }}/$IMAGE_NAME
+            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
+            docker push $PUBLIC_IMAGE_NAME:latest
 
 
   lint-dockerfile:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,10 @@ RUN --mount=type=cache,target=/root/.cache \
 FROM base-python as release-hatch-base
 
 # Create a non-root user to run the app as
-RUN useradd --create-home appuser
+# We currently use host bind mounts in production backends, which means if we
+# need to match the uid inside the container to the one on the host.  To do
+# this, we reserve uid/gid 10000 to use as our running user on the host.
+RUN useradd --create-home --user-group --uid 10000 appuser
 
 # copy venv over from builder image. These will have root:root ownership, but
 # are readable by all.
@@ -151,7 +154,8 @@ CMD ["/app/docker/entrypoints/dev.sh"]
 
 # in dev, ensure appuser uid matches host user id
 ARG USERID=1000
-RUN usermod -u $USERID appuser
+ARG GROUPID=1000
+RUN usermod -u $USERID appuser && groupmod -g $GROUPID appuser
 
 # switch back to appuser
 USER appuser

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,8 @@
 # configuring the production build
 services:
   prod:
-    image: release-hatch-prod
+    # image name, both locally and public
+    image: release-hatch
     build:
       context: ..
       # path relative to context
@@ -37,15 +38,17 @@ services:
         service: prod
     image: release-hatch-dev
     container_name: release-hatch-dev
-    # running as a specific user id allows files written to mounted volumes by
-    # the docker container's default user to match the host uid, for convienience.
-    user: ${DOCKER_USERID:-1000}
+    # running as a specific uid/gid allows files written to mounted volumes by
+    # the docker container's default user to match the host user's uid/gid, for
+    # convienience.
+    user: ${DOCKER_USERID:-1000}:${DOCKER_GROUPID:-1000}
     build:
       # the dev stage in the Dockerfile
       target: release-hatch-dev
-      # pass the user id as build arg (default to 1000)
+      # pass the uid/gid as build arg
       args:
         - USERID=${DOCKER_USERID:-1000}
+        - GROUPID=${DOCKER_GROUPID:-1000}
     # paths relative to docker-compose.yaml file
     env_file:
       - ../.env

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,4 +1,5 @@
 export DOCKER_USERID := `id -u`
+export DOCKER_GROUPID := `id -g`
 
 
 build env="dev":
@@ -22,5 +23,15 @@ test: build
 
 
 # run dev server in docker container
-run: build
+serve: build
     docker-compose up dev
+
+
+# run command in dev container
+run *args="bash": build
+    docker-compose run dev {{ args }}
+
+
+# exec command in existing dev container
+exec *args="bash": build
+    docker-compose exec dev {{ args }}

--- a/justfile
+++ b/justfile
@@ -131,5 +131,15 @@ docker-test: _env
 
 
 # run dev server in docker container
-docker-run: _env
-    {{ just_executable() }} docker/run
+docker-serve: _env
+    {{ just_executable() }} docker/serve
+
+
+# run cmd in dev docker continer
+docker-run *args="bash": _env
+    {{ just_executable() }} docker/run {{ args }}
+
+
+# exec command in an existing dev docker container
+docker-exec *args="bash": _env
+    {{ just_executable() }} docker/exec {{ args }}


### PR DESCRIPTION
The main change is that we hardcode a prod uid/gid. This allows us to
use bind mounting directories in prod

Also clean up some of the docker justfile commands

 * rename `docker-run` to `docker-serve`
 * add `docker-run ...` as a wrapper round invoking `docker run ...`
 * add `docker-exec ...` as a wrapper round invoking `docker exec ...`

Also clean up the naming of images in docker-compose to drop the
unnecessary and brittle `-prod` suffix for the prod image.
