### PR TITLE
Rename environment variables to match job-runner

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -65,5 +65,5 @@ WORKSPACE.
 
 ## Communicate with local job-runner
 
-You will need to set your `BACKEND_TOKEN` value in .env to match the token value in
+You will need to set your `JOB_SERVER_TOKEN` value in .env to match the token value in
 job-server and restart.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ uploading.
 It has no database, all state is derived from the directories and files found
 on disk.
 
-It is authenticated via a token signed by the configured `BACKEND_TOKEN`, which
-is a shared key between job-server and all services for a backend, and it uses
-the same token to authenticate against the job-server to upload files.
+It is authenticated via a token signed by the configured `JOB_SERVER_TOKEN`, which
+is a shared key between job-server and all services for a specific backend, and
+it uses the same token to authenticate against the job-server to upload files.
 
 
 Please see the [additional information](DEVELOPERS.md) for developers.

--- a/dev-token.py
+++ b/dev-token.py
@@ -17,10 +17,10 @@ def token(argv=sys.argv):
 
     args = parser.parse_args(argv[1:])
 
-    url = urljoin(config.SERVER_HOST, f"/workspace/{args.workspace}")
+    url = urljoin(config.RELEASE_HOST, f"/workspace/{args.workspace}")
     expiry = datetime.now(timezone.utc) + timedelta(minutes=args.duration)
     token = signing.AuthToken(url=url, user=args.user, expiry=expiry)
-    print(token.sign(config.BACKEND_TOKEN, salt="hatch"))
+    print(token.sign(config.JOB_SERVER_TOKEN, salt="hatch"))
 
 
 if __name__ == "__main__":

--- a/dotenv-sample.env
+++ b/dotenv-sample.env
@@ -1,10 +1,11 @@
-BACKEND_TOKEN="really really really really really really really long secret"
+# secret token shared with job server for this backend
+JOB_SERVER_TOKEN="really really really really really really really long secret"
 
-# local dev server
-SERVER_HOST=http://127.0.0.1:8001
+# job-server location (default to local job-server in dev)
+JOB_SERVER_ENDPOINT=http://127.0.0.1:8000
 
-# local job-server
-API_SERVER=http://127.0.0.1:8000
+# the full address that release-hatch will be running at (default to local in dev)
+RELEASE_HOST=http://127.0.0.1:8001
 
 # workspaces dir
 WORKSPACES=./workspaces

--- a/hatch/api_client.py
+++ b/hatch/api_client.py
@@ -6,7 +6,8 @@ from hatch import config
 
 # using a module level client should keep the connection open to job-server
 client = httpx.Client(
-    base_url=config.API_SERVER, headers={"Authorization": config.BACKEND_TOKEN}
+    base_url=config.JOB_SERVER_ENDPOINT,
+    headers={"Authorization": config.JOB_SERVER_TOKEN},
 )
 
 
@@ -66,7 +67,7 @@ def _proxy_headers(orig_headers):
     for header in ["Connection", "Server"]:
         headers.pop(header, None)
     # add in proxy info
-    headers["Via"] = config.SERVER_HOST
+    headers["Via"] = config.RELEASE_HOST
     return headers
 
 

--- a/hatch/config.py
+++ b/hatch/config.py
@@ -15,9 +15,11 @@ else:  # pragma: no cover
     CACHE = Path(CACHE)
     assert CACHE.exists()
 
-BACKEND_TOKEN = os.environ.get("BACKEND_TOKEN")
-assert BACKEND_TOKEN
+JOB_SERVER_TOKEN = os.environ.get("JOB_SERVER_TOKEN")
+assert JOB_SERVER_TOKEN
 BACKEND = os.environ.get("BACKEND", "test-backend")
 
-API_SERVER = os.environ.get("API_SERVER", "https://jobs.opensafely.org")
-SERVER_HOST = os.environ.get("SERVER_HOST")
+JOB_SERVER_ENDPOINT = os.environ.get(
+    "JOB_SERVER_ENDPOINT", "https://jobs.opensafely.org"
+)
+RELEASE_HOST = os.environ.get("RELEASE_HOST")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,9 @@ import pytest
 
 
 # force testing config
-os.environ["BACKEND_TOKEN"] = secrets.token_hex(32)
-os.environ["SERVER_HOST"] = "http://testserver"
-os.environ["API_SERVER"] = "https://jobs.opensafely.org"
+os.environ["JOB_SERVER_TOKEN"] = secrets.token_hex(32)
+os.environ["RELEASE_HOST"] = "http://testserver"
+os.environ["JOB_SERVER_ENDPOINT"] = "https://jobs.opensafely.org"
 
 # now we can import hatch stuff
 from hatch import config  # noqa: E402

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -9,7 +9,7 @@ from hatch import api_client, config, schema
 
 def test_create_release(httpx_mock):
     httpx_mock.add_response(
-        url=config.API_SERVER + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
         method="POST",
         status_code=201,
         headers={
@@ -31,13 +31,13 @@ def test_create_release(httpx_mock):
 
     request = httpx_mock.get_request()
     assert request.headers["OS-User"] == "user"
-    assert request.headers["Authorization"] == config.BACKEND_TOKEN
+    assert request.headers["Authorization"] == config.JOB_SERVER_TOKEN
     assert json.loads(request.read()) == {"files": {"file.txt": "sha"}}
 
 
 def test_create_release_error(httpx_mock):
     httpx_mock.add_response(
-        url=config.API_SERVER + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
         method="POST",
         status_code=400,
         json={"detail": "error"},
@@ -62,7 +62,7 @@ def test_create_release_error(httpx_mock):
 
 def test_upload_file(httpx_mock, tmp_path):
     httpx_mock.add_response(
-        url=config.API_SERVER + "/api/v2/releases/release/release_id",
+        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/release/release_id",
         method="POST",
         status_code=201,
         headers={
@@ -81,7 +81,7 @@ def test_upload_file(httpx_mock, tmp_path):
 
     request = httpx_mock.get_request()
     assert request.headers["OS-User"] == "user"
-    assert request.headers["Authorization"] == config.BACKEND_TOKEN
+    assert request.headers["Authorization"] == config.JOB_SERVER_TOKEN
     assert (
         request.headers["Content-Disposition"]
         == 'attachment; filename="output/file.txt"'
@@ -91,7 +91,7 @@ def test_upload_file(httpx_mock, tmp_path):
 
 def test_upload_file_error(httpx_mock, tmp_path):
     httpx_mock.add_response(
-        url=config.API_SERVER + "/api/v2/releases/release/release_id",
+        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/release/release_id",
         method="POST",
         status_code=400,
         json={"detail": "error"},

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,7 +117,7 @@ def test_validate_release_valid(workspace):
 
 def test_create_release(workspace, httpx_mock):
     httpx_mock.add_response(
-        url=config.API_SERVER + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
         method="POST",
         status_code=201,
         headers={"Location": "https://url", "Release-Id": "id"},
@@ -145,7 +145,7 @@ def test_create_release(workspace, httpx_mock):
 
 def test_create_release_error(workspace, httpx_mock):
     httpx_mock.add_response(
-        url=config.API_SERVER + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
         method="POST",
         status_code=400,
         json={"detail": "error"},


### PR DESCRIPTION
This allows them to share the same env file in prod.

Also, changed SERVER_HOST to RELEASE_HOST, so it was more obvious
