### PR TITLE
Remove index endpoint trailing slashes

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -94,7 +94,7 @@ async def aioexists(path):
         return True
 
 
-@app.get("/workspace/{workspace}/current/", response_model=schema.IndexSchema)
+@app.get("/workspace/{workspace}/current", response_model=schema.IndexSchema)
 def workspace_index(
     workspace: str, request: Request, token: AuthToken = Depends(validate)
 ):
@@ -128,7 +128,7 @@ async def workspace_file(
     )
 
 
-@app.post("/workspace/{workspace}/release/")
+@app.post("/workspace/{workspace}/release")
 def workspace_release(
     workspace: str,
     release: schema.Release,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -167,13 +167,13 @@ def test_file_api(workspace):
 
 
 def test_workspace_release_no_data():
-    url = "/workspace/workspace/release/"
+    url = "/workspace/workspace/release"
     response = client.post(url, headers=auth_headers())
     assert response.status_code == 422
 
 
 def test_workspace_release_workspace_not_exists():
-    url = "/workspace/notexists/release/"
+    url = "/workspace/notexists/release"
     response = client.post(
         url,
         json=schema.Release(files={}).dict(),
@@ -187,7 +187,7 @@ def test_workspace_release_workspace_bad_sha(workspace):
 
     release = schema.Release(files={"output/file1.txt": "badhash"})
 
-    url = "/workspace/workspace/release/"
+    url = "/workspace/workspace/release"
     response = client.post(
         url,
         data=release.json(),
@@ -212,7 +212,7 @@ def test_workspace_release_success(workspace, httpx_mock):
         files={"output/file.txt": workspace.get_sha("output/file.txt")}
     )
 
-    url = "/workspace/workspace/release/"
+    url = "/workspace/workspace/release"
     response = client.post(
         url,
         json=release.dict(),


### PR DESCRIPTION
We wanted to avoid lots of redirects in the logs by having job-server
serve URLs with trailing slashes but due to the way the furl library
produces URLs that made life just slightly more difficult (lots of
`f.url + "/"` which had to be explained).  So it seemed simpler to
remove the trailing slashes here.  Since the SPA isn't using these URLs
to construct further URLs this won't affect other parts of the stack.