### PR TITLE
Add new explicit SPA_ORIGIN config and use for CORS

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -21,7 +21,7 @@ app = FastAPI()
 # Allow SPA to access these files
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[config.JOB_SERVER_ENDPOINT],
+    allow_origins=[config.SPA_ORIGIN],
     # credentials here is cookies, we don't use them
     allow_credentials=False,
     # allow caching for 1 hour

--- a/hatch/config.py
+++ b/hatch/config.py
@@ -26,6 +26,9 @@ JOB_SERVER_ENDPOINT = os.environ.get(
 )
 RELEASE_HOST = os.environ.get("RELEASE_HOST")
 
+# used for CORS checking, defaults to job server but is overridable
+SPA_ORIGIN = os.environ.get("SPA_ORIGIN", "https://jobs.opensafely.org")
+
 DEBUG_LEVEL = os.environ.get("DEBUG", "info")
 
 


### PR DESCRIPTION
Using JOBSERVER_API_ENDPOINT was a bug, as it includes the path
`/api/v2`, which breaks CORS preflight checks, as it's not an exact
match to the `Origin:` header send by browser.

Instead, we add explicit config, with a production default of
https://jobs.opensafely.org. This allows local override in dev, but the
default value works in prod.
