### PR TITLE
Fix bad test config that was hiding errors

### DIFF
--- a/hatch/api_client.py
+++ b/hatch/api_client.py
@@ -35,7 +35,7 @@ def create_release(workspace, release, user):
     response object, so we can send it straight to the client.
     """
     response = client.post(
-        url=f"/api/v2/releases/workspace/{workspace}",
+        url=f"/releases/workspace/{workspace}",
         content=release.json(),
         headers={
             "OS-User": user,
@@ -57,7 +57,7 @@ def upload_file(release_id, name, path, user):
     response object, so we can send it straight to the client.
     """
     response = client.post(
-        url=f"/api/v2/releases/release/{release_id}",
+        url=f"/releases/release/{release_id}",
         content=path.read_bytes(),
         headers={
             "OS-User": user,

--- a/hatch/app.py
+++ b/hatch/app.py
@@ -123,9 +123,7 @@ async def workspace_file(
     # FastAPI supports async file responses
     return FileResponse(
         path,
-        headers={
-            "Content-Security-Policy": f"frame-src: {config.JOB_SERVER_ENDPOINT};"
-        },
+        headers={"Content-Security-Policy": f"frame-src: {config.SPA_ORIGIN};"},
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 # force testing config
 os.environ["JOB_SERVER_TOKEN"] = secrets.token_hex(32)
 os.environ["RELEASE_HOST"] = "http://testserver"
-os.environ["JOB_SERVER_ENDPOINT"] = "https://jobs.opensafely.org"
 
 # now we can import hatch stuff
 from hatch import config  # noqa: E402

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -10,7 +10,7 @@ from hatch import api_client, config, schema
 
 def test_create_release(httpx_mock):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
         method="POST",
         status_code=201,
         headers={
@@ -40,7 +40,7 @@ def test_create_release(httpx_mock):
 
 def test_create_release_error(httpx_mock):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
         method="POST",
         status_code=400,
         json={"detail": "error"},
@@ -67,7 +67,7 @@ def test_create_release_error(httpx_mock):
 
 def test_upload_file(httpx_mock, tmp_path):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/release/release_id",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/release/release_id",
         method="POST",
         status_code=201,
         headers={
@@ -98,7 +98,7 @@ def test_upload_file(httpx_mock, tmp_path):
 
 def test_upload_file_error(httpx_mock, tmp_path):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/release/release_id",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/release/release_id",
         method="POST",
         status_code=400,
         json={"detail": "error"},

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,12 +32,12 @@ def test_cors():
     response = client.options(
         "/workspace/workspace/current",
         headers={
-            "Origin": config.JOB_SERVER_ENDPOINT,
+            "Origin": config.SPA_ORIGIN,
             "Access-Control-Request-Method": "GET",
         },
     )
     assert response.headers["Access-Control-Allow-Methods"] == "GET, HEAD, POST"
-    assert response.headers["Access-Control-Allow-Origin"] == config.JOB_SERVER_ENDPOINT
+    assert response.headers["Access-Control-Allow-Origin"] == config.SPA_ORIGIN
     assert response.headers["Access-Control-Max-Age"] == "3200"
     assert "Authorization" in response.headers["access-control-allow-headers"]
 
@@ -162,7 +162,7 @@ def test_file_api(workspace):
     assert response.content == b"test"
     assert (
         response.headers["Content-Security-Policy"]
-        == f"frame-src: {config.JOB_SERVER_ENDPOINT};"
+        == f"frame-src: {config.SPA_ORIGIN};"
     )
 
 
@@ -201,7 +201,7 @@ def test_workspace_release_workspace_bad_sha(workspace):
 
 def test_workspace_release_success(workspace, httpx_mock):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
         method="POST",
         status_code=201,
         headers={
@@ -342,7 +342,7 @@ def test_release_file_upload_bad_file(release):
 
 def test_release_file_upload(release, httpx_mock):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + f"/api/v2/releases/release/{release.id}",
+        url=config.JOB_SERVER_ENDPOINT + f"/releases/release/{release.id}",
         method="POST",
         status_code=201,
         headers={

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,7 +117,7 @@ def test_validate_release_valid(workspace):
 
 def test_create_release(workspace, httpx_mock):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
         method="POST",
         status_code=201,
         headers={
@@ -150,7 +150,7 @@ def test_create_release(workspace, httpx_mock):
 
 def test_create_release_error(workspace, httpx_mock):
     httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/api/v2/releases/workspace/workspace",
+        url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
         method="POST",
         status_code=400,
         json={"detail": "error"},


### PR DESCRIPTION
A while back, we separated JOB_SERVER_ENDPOINT (which had a /api/v2 path
prefix) and SPA_ORIGIN (which did not). But the tests sadly used an old
test value of JOB_SERVER_ENDPOINT by default that did not include
the path prefix. Thus all the api calls added the /api/v2 prefix, and everything
worked in test.

This happened to go unnoticed, as the TPP install of release-hatch *also* had an
incorrectly configured JOB_SERVER_ENDPOINT w/o the prefix, so stuff
worked.

However, in test and emis backends, the JOB_SERVER_ENDPOINT does
have a prefix, as it is shared with job-runner config. So release-hatch
ended up double prefixing things, and thus 404s abounded.

The solution is not to have a separate test config, and test the default
value, which includes the prefix. This exposed all the issues in the tests, and was able to fix stuff.