### PR TITLE
fix: remove docker volumes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,8 +90,6 @@ ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
 
 RUN mkdir /app
 WORKDIR /app
-VOLUME /app
-VOLUME /workspaces
 
 # This may not be necessary, but it probably doesn't hurt
 ENV PYTHONPATH=/app

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,3 +1,5 @@
+set dotenv-load := true
+
 export DOCKER_USERID := `id -u`
 export DOCKER_GROUPID := `id -g`
 


### PR DESCRIPTION
The volume mounts were originally added as metadata, but it turns out if you don't supply a mount, docker creates one for you with the contents of that dir in your that lasts beyond the containers lifetime and eats disk.
