### PR TITLE
fix: decouple validating hostname from path.

### DIFF
--- a/hatch/signing.py
+++ b/hatch/signing.py
@@ -7,6 +7,7 @@
 # file into your project.
 import hashlib
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import itsdangerous
 from pydantic import BaseModel, Field, root_validator, validator
@@ -84,10 +85,15 @@ class AuthToken(BaseModel):
 
     @validator("url")
     def check_url(cls, url):
-        """Enforce that we need a fully qualified url."""
-        if url.startswith(("http://", "https://")):
-            return url
-        raise ValueError(f"Invalid url '{url}'")
+        """Enforce that we need a url with scheme, hostname and path."""
+        try:
+            parsed = urlparse(url)
+            assert parsed.scheme in ("http", "https"), "Invalid scheme"
+            assert parsed.hostname, "No hostname"
+        except Exception as exc:
+            raise ValueError(f"Invalid url '{url}': {exc}")
+
+        return url
 
     @validator("expiry")
     def check_expiry(cls, expiry):

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -34,13 +34,26 @@ def test_token_sign_verify_roundtrip(secret_key):
     assert token1 == token2
 
 
-def test_token_object_url_invalid():
-    with pytest.raises(ValidationError):
+@pytest.mark.parametrize(
+    "url,msg",
+    [
+        ("bad://host/path", "Invalid scheme"),
+        ("http://", "No hostname"),
+        ("", "Invalid scheme"),
+    ],
+)
+def test_token_object_url_invalid(url, msg, caplog):
+    with pytest.raises(ValidationError) as exc:
         signing.AuthToken(
-            url="bad",
+            url=url,
             user="user",
             expiry=datetime.now(timezone.utc) + timedelta(minutes=1),
         )
+
+    assert (
+        str(exc.value)
+        == f"1 validation error for AuthToken\nurl\n  Invalid url '{url}': {msg} (type=value_error)"
+    )
 
 
 def test_token_object_expired():


### PR DESCRIPTION
Previously, release-hatch validated that the full url we were handling
matched the token url prefix.

This meant we could only support one valid host. This has proved
problematic, as this included the port. For various reasons, EMIS users
access via one port when viewing outputs (because SSH forwarding)
and another when releasing outputs via `osrelease`. Also, localhost is
common access for testing and other operations, so it would be nice to
support that as an option.

This PR decouples the url validation into a hostname check (w/o ports),
and a path check.

It also tightens up the validation of urls in the signed token, so a url
must be valid.
