### PR TITLE
Add support to request a release via the SPA.

### DIFF
--- a/hatch/schema.py
+++ b/hatch/schema.py
@@ -24,30 +24,36 @@ class UrlFileName(str):
         return str(value).replace("\\", "/")
 
 
-class FileSchema(BaseModel):
+class FileMetadata(BaseModel):
     """Metadata for a workspace file."""
 
     name: UrlFileName
-    url: UrlFileName
-    size: int
-    sha256: str
-    user: str = None
-    date: datetime = None
+    url: UrlFileName = None  # Url to path on release-hatch instance
+    size: int  # size in bytes
+    sha256: str  # sha256 of file
+    date: datetime  # last modified in ISO date format
+    metadata: dict = None  # user supplied metadata about this file
 
 
-class IndexSchema(BaseModel):
+class FileList(BaseModel):
     """An index of files in a workspace.
 
     This must match the json format that the SPA's client API expects.
     """
 
-    files: List[FileSchema]
+    files: List[FileMetadata]
+
+
+# osrelease API, not used by SPA API
 
 
 class Release(BaseModel):
-    """Request a release.
+    """A request from osrelease for a set of files to released.
 
-    Files is a dict with {name: sha256} mapping.
+    Files is a dict with {name: sha256} mapping. We get the client to send the
+    hash that was viewed, in case the file has changed on disk since the user
+    viewed it.
+
     """
 
     files: Dict[UrlFileName, str]
@@ -56,9 +62,8 @@ class Release(BaseModel):
 class ReleaseFile(BaseModel):
     """File to upload to job-server.
 
-    This schema is unique to the release-hatch API, as the client just
-    indicates which file release-hatch should upload, rather than uploading the
-    bytes itself.
+    This schema is unique to the osrelease release-hatch API. The SPA uses
+    a background upload process, rather than an user API to trigger it.
     """
 
     name: UrlFileName

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 #
-anyio==3.2.1 \
-    --hash=sha256:07968db9fa7c1ca5435a133dc62f988d84ef78e1d9b22814a59d1c62618afbc5 \
-    --hash=sha256:442678a3c7e1cdcdbc37dcfe4527aa851b1b0c9162653b516e9f509821691d50
+anyio==3.6.1 \
+    --hash=sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b \
+    --hash=sha256:cb29b9c70620506a9a8f87a309591713446953302d7d995344d0d7c6c0c9a7be
     # via
     #   -c requirements.prod.txt
     #   httpcore
@@ -321,6 +321,13 @@ tomli==1.2.0 \
     #   black
     #   build
     #   pep517
+typing-extensions==3.10.0.0 \
+    --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
+    --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
+    --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+    # via
+    #   -c requirements.prod.txt
+    #   black
 virtualenv==20.6.0 \
     --hash=sha256:51df5d8a2fad5d1b13e088ff38a433475768ff61f202356bb9812c454c20ae45 \
     --hash=sha256:e4fc84337dce37ba34ef520bf2d4392b392999dbe47df992870dc23230f6b758


### PR DESCRIPTION
This modifies the release creation API to support an alternate payload
POSTed from the SPA, rather than the current minimal osrelease payload.

This alternate payload is the same json format as the data we sent to
the SPA, so should be easy to reflect back. It includes an extra field,
`metadata`, to be populated by the SPA. We also remove the `user` field
as it was not used.

This consolidates the json schema to a single playload type, the
FileList, which is used for both listing files and requesting files for
review, which is much simpler. As such, it has been renamed to be
reflect its more general purpose.

There are few places where we have to branch to handle the appropriate
payload. Once the release UI in SPA is fully launched, we should be able
to delete the osrelease method.
