### PR TITLE
Add release level metadata to the review API

### DIFF
--- a/hatch/schema.py
+++ b/hatch/schema.py
@@ -42,6 +42,7 @@ class FileList(BaseModel):
     """
 
     files: List[FileMetadata]
+    metadata: dict = None  # user supplied metadata about these files
 
 
 # osrelease API, not used by SPA API

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -56,6 +56,7 @@ def test_create_release_spa(httpx_mock, workspace):
     workspace.write("output/file1.txt", "test1")
     filelist = models.get_index(workspace.path)
     filelist.files[0].metadata = {"test": "test"}
+    filelist.metadata = {"foo": "bar"}
 
     response = api_client.create_release("workspace", filelist, "user")
 
@@ -77,7 +78,8 @@ def test_create_release_spa(httpx_mock, workspace):
                 "date": workspace.get_date("output/file1.txt"),
                 "metadata": {"test": "test"},
             },
-        ]
+        ],
+        "metadata": {"foo": "bar"},
     }
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -165,7 +165,8 @@ def test_index_api(workspace):
                 "date": workspace.get_date("output/file2.txt"),
                 "metadata": None,
             },
-        ]
+        ],
+        "metadata": None,
     }
 
 
@@ -283,6 +284,7 @@ def test_workspace_release_success_spa(workspace, httpx_mock):
     workspace.write("output/file.txt", "test")
 
     filelist = models.get_index(workspace.path)
+    filelist.metadata = {"foo": "bar"}
 
     url = "/workspace/workspace/release"
     response = client.post(
@@ -348,7 +350,8 @@ def test_release_index_api(release):
                 "date": release.get_date("output/file2.txt"),
                 "metadata": None,
             },
-        ]
+        ],
+        "metadata": None,
     }
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -88,7 +88,8 @@ def test_get_index(workspace):
                 "date": workspace.get_date("output/file2.txt", iso=False),
                 "metadata": None,
             },
-        ]
+        ],
+        "metadata": None,
     }
 
 


### PR DESCRIPTION
This provides a place to put whole-release level fields that users may
need to fill in. We just pass it through to job-server.
