### PR TITLE
cli tool refactor

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -17,7 +17,10 @@ from hatch.signing import AuthToken
 
 config.setup_logging()
 logger = logging.getLogger(__name__)
-app = FastAPI()
+app = FastAPI(
+    title="release-hatch",
+    description="OpenSAFELY backend release management service",
+)
 
 
 # Allow SPA to access these files

--- a/justfile
+++ b/justfile
@@ -99,7 +99,6 @@ test *ARGS: devenv
     $BIN/python -m pytest --cov=. --cov-report html --cov-report term-missing:skip-covered {{ ARGS }}
 
 
-# runs the format (black), sort (isort) and lint (flake8) check but does not change any files
 check: devenv
     $BIN/black --check .
     $BIN/isort --check-only --diff .
@@ -115,13 +114,14 @@ fix: devenv
 # Run the dev project
 run:
     #!/usr/bin/env bash
+    set -eux
     port=$(echo $RELEASE_HOST | awk -F: '{print $3}' | tr -d / )
     $BIN/uvicorn hatch.app:app --reload --port ${port:-8000}
 
 
 # Run the test client
 client *ARGS:
-    @PTHONPATH=. $BIN/python ./hatch/client.py {{ ARGS }}
+    @PYTHONPATH=. $BIN/python ./hatch/client.py {{ ARGS }}
 
 
 # build docker image env=dev|prod

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -104,7 +104,9 @@ typing-extensions==3.10.0.0 \
     --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
     --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
     --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
-    # via pydantic
+    # via
+    #   pydantic
+    #   starlette
 urllib3==1.26.6 \
     --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
     --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f


### PR DESCRIPTION
Refactor cli arguments and clean it up a bit in preparation for adding
a new command

Also, remove the time.sleep() calls in the functional tests with some
trickery. Saves about 6-8s of the test run times on my machine.
