### PR TITLE
Remove old release API support

### DIFF
--- a/hatch/app.py
+++ b/hatch/app.py
@@ -1,6 +1,5 @@
 import logging
 from functools import partial
-from typing import Union
 from urllib.parse import urlparse
 
 import aiofiles.os
@@ -153,7 +152,7 @@ def workspace_release(
     request: Request,
     workspace: str,
     # currently this API accept the osrelease json or the SPA version
-    filelist: Union[schema.Release, schema.FileList],
+    filelist: schema.FileList,
     token: AuthToken = Depends(validate),
 ):
     """Create a Release locally and in job-server."""

--- a/hatch/client.py
+++ b/hatch/client.py
@@ -160,8 +160,7 @@ def test_cmd(args):  # pragma: no cover
 
 def request_cmd(args):  # pragma: no cover
     token = get_token(args)
-    index = fetch_index(token, args.workspace)
-    files = {f["name"]: f for f in index["files"]}
+    index = schema.FileList(**fetch_index(token, args.workspace))
 
     filelist = schema.FileList(files=[])
     if args.metadata:
@@ -169,7 +168,7 @@ def request_cmd(args):  # pragma: no cover
 
     for arg in args.files:
         p, _, metadata = arg.partition(":")
-        filedata = files.get(p)
+        filedata = index.get(p)
         if filedata is None:
             sys.exit(f"{p} does not exist")
 

--- a/hatch/models.py
+++ b/hatch/models.py
@@ -89,22 +89,15 @@ def validate_release_files(workspace, directory, filelist):
     This can be used on the raw workspace files or on the release directory.
     """
     errors = []
-
-    # handle old/new release schemas
-    if isinstance(filelist, FileList):
-        hashes = {r.name: r.sha256 for r in filelist.files}
-    else:
-        hashes = filelist.files
-
-    for name, sha in hashes.items():
-        p = directory / name
+    for f in filelist.files:
+        p = directory / f.name
         if not p.exists():
             errors.append(
-                f"File {name} not found in {directory} for workspace {workspace}"
+                f"File {f.name} not found in {directory} for workspace {workspace}"
             )
-        elif sha != get_sha(p):
+        elif f.sha256 != get_sha(p):
             errors.append(
-                f"File {name} in {directory} does not match expected sha of '{sha}'"
+                f"File {f.name} in {directory} does not match expected sha of '{f.sha256}'"
             )
 
     return errors
@@ -134,10 +127,7 @@ def create_release(workspace, workspace_dir, filelist, user):
     tmp = Path(tmpdir.name)
     try:
         # copy files to a temp dir
-        if isinstance(filelist, FileList):
-            copy_files(workspace_dir, [f.name for f in filelist.files], tmp)
-        else:
-            copy_files(workspace_dir, filelist.files, tmp)
+        copy_files(workspace_dir, [f.name for f in filelist.files], tmp)
 
         # tell job-server about the files
         response = api_client.create_release(workspace, filelist, user)

--- a/hatch/schema.py
+++ b/hatch/schema.py
@@ -7,7 +7,7 @@
 # file into your project.
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List
+from typing import List
 
 from pydantic import BaseModel
 
@@ -57,20 +57,12 @@ class FileList(BaseModel):
     metadata: dict = None  # user supplied metadata about thse Release
     review: dict = None  # review comments for the whole Release
 
-
-# osrelease API, not used by SPA API
-
-
-class Release(BaseModel):
-    """A request from osrelease for a set of files to released.
-
-    Files is a dict with {name: sha256} mapping. We get the client to send the
-    hash that was viewed, in case the file has changed on disk since the user
-    viewed it.
-
-    """
-
-    files: Dict[UrlFileName, str]
+    def get(self, name):  # pragma: no cover
+        name = str(name)
+        for f in self.files:
+            if f.name == name:
+                return f
+        return None
 
 
 class ReleaseFile(BaseModel):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -8,37 +8,7 @@ from fastapi import HTTPException
 from hatch import api_client, config, models, schema
 
 
-def test_create_release_osrelease(httpx_mock):
-    httpx_mock.add_response(
-        url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
-        method="POST",
-        status_code=201,
-        headers={
-            "Location": "https://url",
-            "Release-Id": "id",
-            "Connection": "close",
-            "Server": "server",
-            "Content-Length": "100",
-            "Content-Type": "application/json",
-        },
-    )
-
-    release = schema.Release(files={"file.txt": "sha"})
-
-    response = api_client.create_release("workspace", release, "user")
-
-    assert response.headers["Location"] == "https://url"
-    assert response.headers["Release-Id"] == "id"
-    assert "Connection" not in response.headers
-    assert "Server" not in response.headers
-
-    request = httpx_mock.get_request()
-    assert request.headers["OS-User"] == "user"
-    assert request.headers["Authorization"] == config.JOB_SERVER_TOKEN
-    assert json.loads(request.read()) == {"files": {"file.txt": "sha"}}
-
-
-def test_create_release_spa(httpx_mock, workspace):
+def test_create_release(httpx_mock, workspace):
     httpx_mock.add_response(
         url=config.JOB_SERVER_ENDPOINT + "/releases/workspace/workspace",
         method="POST",
@@ -100,10 +70,10 @@ def test_create_release_error(httpx_mock):
         },
     )
 
-    release = schema.Release(files={"file.txt": "sha"})
+    filelist = schema.FileList(files=[])
 
     with pytest.raises(HTTPException) as exc_info:
-        api_client.create_release("workspace", release, "user")
+        api_client.create_release("workspace", filelist, "user")
 
     response = exc_info.value
     assert response.headers["Some-header"] == "value"


### PR DESCRIPTION
We are moving osrelease to use the new API, so we do not need to support
both simultaneously.
